### PR TITLE
Update a redirected link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Feedback and contributions are welcome!
   - [Others](#others)
 
 ## Basics
-- [A 2019 guide to Human Pose Estimation with Deep Learning](https://blog.nanonets.com/human-pose-estimation-2d-guide/?utm_source=reddit&utm_medium=social&utm_campaign=pose&utm_content=GROUP_NAME)
+- [A 2019 guide to Human Pose Estimation with Deep Learning](https://nanonets.com/blog/human-pose-estimation-2d-guide/)
 
 
 ## Papers


### PR DESCRIPTION
The link in "Basics" and  "2D and 3D estimations" are all dead links since a change in the blog domain. Found the basics new link but not sure about the other two links.

Actual link: https://nanonets.com/blog/human-pose-estimation-2d-guide/
Check in the wayback machine: https://web.archive.org/web/20190417040646/https://blog.nanonets.com/human-pose-estimation-2d-guide/?utm_source=reddit&utm_medium=social&utm_campaign=pose&utm_content=GROUP_NAME

Im not sure where are the links for the "2D and 3D estimations" but at least 2D estimation seems to be in the same link i found.